### PR TITLE
Visual Studio 2015

### DIFF
--- a/ami/cfn-ami-win2012-vs2015.template
+++ b/ami/cfn-ami-win2012-vs2015.template
@@ -25,7 +25,7 @@
         "WindowsM3large": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": "ami-3214ac5a",
+                "ImageId": "ami-6f2cf804",
                 "InstanceType": "m3.large",
                 "KeyName": "tilestream",
                 "SecurityGroupIds": [ { "Ref": "Security" } ],
@@ -44,7 +44,7 @@
                 "UserData": { "Fn::Base64": { "Fn::Join": [ "\r\n", [
                     "<powershell>",
                     "([ADSI]\"WinNT://./Administrator\").SetPassword(\"Plato1234\")",
-                    "Invoke-WebRequest http://download.microsoft.com/download/A/3/F/A3F9ABF8-9AF3-4F64-BD3C-F7ECA64EBA48/vs_professional.exe -OutFile C:\\Users\\Administrator\\Desktop\\vs_professional.exe",
+                    "Invoke-WebRequest http://download.microsoft.com/download/0/B/C/0BC321A4-013F-479C-84E6-4A2F90B11269/vs_community.exe -OutFile C:\\Users\\Administrator\\Desktop\\vs_community.exe",
                     "</powershell>",
                     "<persist>true</persist>"
                 ] ] } }

--- a/ami/cfn-ami-win2012-vs2015.template
+++ b/ami/cfn-ami-win2012-vs2015.template
@@ -44,7 +44,7 @@
                 "UserData": { "Fn::Base64": { "Fn::Join": [ "\r\n", [
                     "<powershell>",
                     "([ADSI]\"WinNT://./Administrator\").SetPassword(\"Plato1234\")",
-                    "Invoke-WebRequest http://download.microsoft.com/download/0/B/C/0BC321A4-013F-479C-84E6-4A2F90B11269/vs_community.exe -OutFile C:\\Users\\Administrator\\Desktop\\vs_community.exe",
+                    "Invoke-WebRequest http://download.microsoft.com/download/D/E/5/DE5263E9-A58D-469A-BA16-14786E2E2B1C/wdexpress_full.exe -OutFile C:\\Users\\Administrator\\Desktop\\wdexpress_full.exe",
                     "</powershell>",
                     "<persist>true</persist>"
                 ] ] } }

--- a/ami/cfn-ami-win2012-vs2015.template
+++ b/ami/cfn-ami-win2012-vs2015.template
@@ -1,0 +1,54 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "template for creating win2012-vs2015 AMI",
+    "Resources": {
+        "Security": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Allow atlas-server-app traffic",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "22",
+                        "ToPort": "22",
+                        "CidrIp": "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "3389",
+                        "ToPort": "3389",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ]
+            }
+        },
+        "WindowsM3large": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": "ami-3214ac5a",
+                "InstanceType": "m3.large",
+                "KeyName": "tilestream",
+                "SecurityGroupIds": [ { "Ref": "Security" } ],
+                "Tags": [ {
+                    "Key": "Name",
+                    "Value": { "Fn::Join": [ " - ", [
+                        { "Ref": "AWS::StackName" }, "windows"
+                    ] ] }
+                } ],
+                "BlockDeviceMappings" : [
+                   {
+                      "DeviceName" : "/dev/sda1",
+                      "Ebs" : { "VolumeSize": "60" }
+                   }
+                ],
+                "UserData": { "Fn::Base64": { "Fn::Join": [ "\r\n", [
+                    "<powershell>",
+                    "([ADSI]\"WinNT://./Administrator\").SetPassword(\"Plato1234\")",
+                    "Invoke-WebRequest http://download.microsoft.com/download/A/3/F/A3F9ABF8-9AF3-4F64-BD3C-F7ECA64EBA48/vs_professional.exe -OutFile C:\\Users\\Administrator\\Desktop\\vs_professional.exe",
+                    "</powershell>",
+                    "<persist>true</persist>"
+                ] ] } }
+            }
+        }
+    }
+}

--- a/cfn-win.template
+++ b/cfn-win.template
@@ -5,7 +5,7 @@
         "OS": {
             "Description": "AMI to use",
             "Type": "String",
-            "AllowedValues" : ["win2012", "win2012-vs2014"]
+            "AllowedValues" : ["win2012", "win2012-vs2014", "win2012-vs2015"]
         },
         "InstanceType": {
             "Description": "EC2 instance type",
@@ -109,6 +109,9 @@
             },
             "win2012-vs2014": {
                 "AMI": "ami-8ce26ce4"
+            },
+            "win2012-vs2015": {
+                "AMI": "TODO"
             }
         }
     }

--- a/cfn-win.template
+++ b/cfn-win.template
@@ -111,7 +111,7 @@
                 "AMI": "ami-8ce26ce4"
             },
             "win2012-vs2015": {
-                "AMI": "TODO"
+                "AMI": "ami-6dcd6806"
             }
         }
     }

--- a/cfn-win.template
+++ b/cfn-win.template
@@ -69,7 +69,7 @@
                 "BlockDeviceMappings" : [
                    {
                       "DeviceName" : "/dev/sda1",
-                      "Ebs" : { "VolumeSize": "60" }
+                      "Ebs" : { "VolumeSize": "160" }
                    }
                 ],
                 "UserData": { "Fn::Base64": { "Fn::Join": [ "\r\n", [

--- a/cfn-win.template
+++ b/cfn-win.template
@@ -69,7 +69,7 @@
                 "BlockDeviceMappings" : [
                    {
                       "DeviceName" : "/dev/sda1",
-                      "Ebs" : { "VolumeSize": "160" }
+                      "Ebs" : { "VolumeSize": "60" }
                    }
                 ],
                 "UserData": { "Fn::Base64": { "Fn::Join": [ "\r\n", [
@@ -111,7 +111,7 @@
                 "AMI": "ami-8ce26ce4"
             },
             "win2012-vs2015": {
-                "AMI": "ami-6dcd6806"
+                "AMI": "ami-13ab0e78"
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ An in-progress Windows build/testing template.
 
 Parameters | Description
 ---------- | -----------
-OS         | AMI to test on (currently: `win2012` or `win2012-vs2014`)
+OS         | AMI to test on (currently: `win2012`, `win2012-vs2014`, or `win2012-vs2015`)
 UserData   | Test script to run
 GithubAccessToken | *Unused*: GitHub access token with repo:status scope
 
@@ -29,3 +29,8 @@ GithubAccessToken | *Unused*: GitHub access token with repo:status scope
 
 A CFN template for building a Windows 2012 + Visual Studio 2014 AMI. AMI creation must
 be done manually after the template has run and VS2014 is successfully installed.
+
+### ami/cfn-ami-win2012-vs2015.template
+
+A CFN template for building a Windows 2012 + Visual Studio 2015 AMI. AMI creation must
+be done manually after the template has run and VS2015 is successfully installed.

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ OS         | AMI to test on (currently: `win2012`, `win2012-vs2014`, or `win2012
 UserData   | Test script to run
 GithubAccessToken | *Unused*: GitHub access token with repo:status scope
 
+To add a new AMI see the steps at https://github.com/mapbox/cfn-ci/pull/4#issue-98029857
+
 ### ami/cfn-ami-win2012-vs2014.template
 
 A CFN template for building a Windows 2012 + Visual Studio 2014 AMI. AMI creation must


### PR DESCRIPTION
Work toward VS 2015 support, needed by mapbox/node-cpp11#23.

Steps to get there:

   - [x] start with a recent 2012 server like https://aws.amazon.com/marketplace/ordering?productId=6880e80b-b23d-4689-877e-02e40bdfe170&ref_=dtl_psb_continue&region=us-east-1
   - [x] tweak cloudfront script to install new visual studio version to its ready to go on the desktop
   - [x] launch via cloudfront template (do this in AWS UI to get around lack of MFA in cfn-config)
   - [x] find instance ip
   - [x] login via RDP
   - [x] manually install visual studio 2015 using default options
   - [x] then save the AMI to `us-east-1` in `sandbox`
 
/cc @yhahn @BergWerkGIS 